### PR TITLE
Add polyfills for IE11 support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@vgs/collect-js",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1686,6 +1686,11 @@
       "integrity": "sha512-5qOlnZscTn4xxM5MeGXAMOsIOIKIbh9e85zJWfBRVPlRMEVawzoPhINYbRGkBZCI8LxvBe7tJCdWiarA99OZfQ==",
       "dev": true
     },
+    "@types/promise-polyfill": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@types/promise-polyfill/-/promise-polyfill-6.0.4.tgz",
+      "integrity": "sha512-GSCjjH6mDS8jgpT22rEOkZVqZcYj7i9AHJu4ntpvoohEpa0mLAKP/Kz3POMKqABaFsS4TyNHOeoyWpzycddcoQ=="
+    },
     "@types/resolve": {
       "version": "1.17.1",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.17.1.tgz",
@@ -1694,6 +1699,11 @@
       "requires": {
         "@types/node": "*"
       }
+    },
+    "@types/setasap": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/setasap/-/setasap-2.0.0.tgz",
+      "integrity": "sha512-nbaj9OJdCiJUM2daJPWO+lgcrp4wR4ZPhwA7s/8+9YstW3/TzMJ4v1tY5RaNUZeOUfAmVXEoXXqsEsQxZ/Zdvw=="
     },
     "@types/stack-utils": {
       "version": "1.0.1",
@@ -6603,6 +6613,11 @@
         }
       }
     },
+    "promise-polyfill": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.2.0.tgz",
+      "integrity": "sha512-k/TC0mIcPVF6yHhUvwAp7cvL6I2fFV7TzF1DuGPI8mBh4QQazf36xCKEHKTZKRysEoTQoQdKyP25J8MPJp7j5g=="
+    },
     "prompts": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.0.tgz",
@@ -7497,6 +7512,11 @@
           }
         }
       }
+    },
+    "setasap": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/setasap/-/setasap-2.0.1.tgz",
+      "integrity": "sha512-DsoqaT3/BB0FTXi8DGMoJse2SGYkUTkOQaCjBx/DJSodGN2EE/rHU9CyJ7H1mYGMyzJvwUlgJQTI4twRg5QY3g=="
     },
     "shebang-command": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -40,8 +40,12 @@
     "typescript": "^4.0.2"
   },
   "dependencies": {
+    "@types/promise-polyfill": "^6.0.4",
+    "@types/setasap": "^2.0.0",
     "@types/uuid": "^8.3.0",
     "axios": "^0.21.1",
+    "promise-polyfill": "8.2.0",
+    "setasap": "^2.0.1",
     "uuid": "^8.3.2"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,6 @@
+import Promise from 'promise-polyfill';
+import setAsap from 'setasap';
+
 import { loadScript } from './utils/loadScript';
 import { registerScriptLoading } from './utils/trackEvent';
 import { initCollect } from './utils/initCollect';
@@ -8,6 +11,8 @@ import { ERROR_MESSAGE, DEFAULT_CONFIG } from './constants';
 import { preFetch } from './sideEffects/preFetch';
 import { preConnect } from './sideEffects/preConnect';
 import { IConfig } from './utils/IConfig';
+
+Promise._immediateFn = setAsap;
 
 // side effects
 Promise.resolve().then(() => {

--- a/src/utils/appendElement.ts
+++ b/src/utils/appendElement.ts
@@ -9,7 +9,7 @@ const appendElement = (elem: HTMLScriptElement | HTMLLinkElement) => {
     );
   }
 
-  target.append(elem);
+  target.appendChild(elem);
   return elem;
 };
 

--- a/src/utils/loadScript.ts
+++ b/src/utils/loadScript.ts
@@ -1,3 +1,4 @@
+import Promise from 'promise-polyfill';
 import { trackEvent } from './trackEvent';
 import { getConfig } from './config';
 import {


### PR DESCRIPTION
## Description
- Added `promise-polyfill` package to handle `Promise` support in IE11. 
- Replaced `.append()` to `.appendChild()` supported in IE11.

## Motivation and Context
Fixes #25 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
