### PR TITLE
Move types to dev dependencies.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4760,7 +4760,8 @@
     "@types/uuid": {
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.0.tgz",
-      "integrity": "sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ=="
+      "integrity": "sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ==",
+      "dev": true
     },
     "@types/yargs": {
       "version": "15.0.12",

--- a/package.json
+++ b/package.json
@@ -35,13 +35,13 @@
   "module": "dist/collect-js.esm.js",
   "devDependencies": {
     "@babel/preset-env": "^7.15.6",
+    "@types/uuid": "^8.3.0",
     "husky": "^4.3.0",
     "tsdx": "^0.14.1",
     "tslib": "^2.0.1",
     "typescript": "^4.0.2"
   },
   "dependencies": {
-    "@types/uuid": "^8.3.0",
     "axios": "^0.21.4",
     "core-js": "^3.17.3",
     "setasap": "^2.0.1",


### PR DESCRIPTION
These types are not re-exported and are only used internally. There's no need to require consumers to take a transitive dependency on them.