### PR TITLE
Bugfix / Fixed wrong examples url

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
 [VGS Collect.js](https://www.verygoodsecurity.com/docs/vgs-collect/js/overview) is a JavaScript library that allows you to securely collect data via any form. Instantly create custom forms that adhere to PCI, HIPAA, GDPR, or CCPA security requirements. [VGS](https://www.verygoodsecurity.com/) intercepts sensitive data before it hits your servers and replaces it with aliased versions while securing the original data in our vault. The form fields behave like traditional forms while preventing access to the unsecured data by injecting secure iframe components.
 
 - [Learn more](https://www.verygoodsecurity.com/docs/vgs-collect/js/overview)
-- [Examples](https://verygoodsecurity.github.io/vgs-collect-examples)
+- [Examples](https://vgs-samples.github.io/vgs-collect-examples/)
 
 ### Why do I need to use this package?
 


### PR DESCRIPTION
## Description
Fix examples url on README document

## Motivation and Context
The examples url on README document is incorrect, its link to 404 not found page:
- [Current link](https://verygoodsecurity.github.io/vgs-collect-examples)
- [Fixed link](https://vgs-samples.github.io/vgs-collect-examples/)

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
