### PR TITLE
chore: add Claude Renovate PR review workflow

### DIFF
--- a/.claude/references/dependency-map.md
+++ b/.claude/references/dependency-map.md
@@ -1,0 +1,69 @@
+# vgs-collect-js Dependency Map
+
+## Project Structure
+
+Single-package Node.js/TypeScript library (`@vgs/collect-js`) that provides a
+script loading module for VGS Collect.js. Built and tested with `tsdx`.
+
+- `src/` -- Library source (entry point, utils, constants, side effects)
+- `test/` -- Unit tests (load, parseVersion, validation)
+- `types/` -- TypeScript type declarations
+- `dist/` -- Build output (CJS + ESM)
+
+## Dependency Categories
+
+### Always Low Risk (Auto-merge Candidates)
+
+| Pattern | Example | Reason |
+|---------|---------|--------|
+| Type definition packages | `@types/uuid` | Compile-time only, no runtime impact |
+| Babel presets (dev) | `@babel/preset-env` | Build-time transpilation only |
+| TypeScript helper lib (dev) | `tslib` | Bundled at build time, minor bumps are safe |
+| CI actions | `actions/checkout` | CI-only, no runtime impact |
+| Lint/format tooling | `husky` | Pre-commit hooks only, no runtime impact |
+
+### Needs Quick Review
+
+| Pattern | Example | Reason | Expected Test Coverage |
+|---------|---------|--------|----------------------|
+| Polyfill library (minor/patch) | `core-js` patch/minor | Runtime dep but polyfills are additive | Unit tests cover core loading behavior |
+| UUID library (patch) | `uuid` patch | Runtime dep, stable API | Unit tests use UUID generation |
+| TypeScript compiler (minor) | `typescript` minor | May affect type checking or build output | Build + test suite validates |
+| Build toolchain (patch) | `tsdx` patch | Affects build/test pipeline | Full test suite run validates |
+
+### Needs Deep Review
+
+| Pattern | Example | Reason | Expected Test Coverage |
+|---------|---------|--------|----------------------|
+| UUID major version bump | `uuid` v8 -> v13 | Major version, potential API breaking changes | Unit tests cover UUID usage in `src/utils/` |
+| TypeScript major version bump | `typescript` v4 -> v5 | May break type checking, new strictness rules | Build must succeed, all tests must pass |
+| Husky major version bump | `husky` v4 -> v9 | Config format changed significantly between majors | Pre-commit hook must still work |
+| Build toolchain major | `tsdx` major | Core build/test infra, can break everything | Full build + test suite |
+| core-js major | `core-js` major | Runtime polyfills, removal/changes can break browser compat | Unit tests + manual browser verification |
+| Dependency pinning PRs | Pin dependencies | Pins can reveal version conflicts or restrict updates | Build + test suite |
+| Override changes | `qs` (via tsdx override) | Security override (`qs@6.5.3`), changes need care | Transitive, verify no regression |
+
+## Historical Patterns (from PR analysis)
+
+There are currently 10 open Renovate PRs, including several major version bumps
+that have been open since late 2025:
+
+- **Major bumps (high risk):** `uuid` v8->v13, `typescript` v4->v5, `husky` v4->v9, `@types/uuid` v8->v11
+- **Minor/patch bumps (lower risk):** `core-js`, `tslib`, `@babel/preset-env`, `qs` override
+- **CI updates:** `actions/checkout` v4->v6
+- **Pinning:** One PR to pin dependencies
+
+The backlog suggests dependency updates have not been actively triaged. Several
+of the major bumps (especially `typescript` and `husky`) will likely require
+config or code changes beyond a simple merge.
+
+## Renovate Configuration
+
+Minimal configuration -- `renovate.json` contains only the JSON schema reference
+with no custom `extends`, labels, grouping, automerge rules, or package rules.
+This means Renovate is running with default settings:
+
+- No automerge enabled
+- No dependency grouping
+- No custom scheduling
+- PRs are labeled with `renovate` by default

--- a/.github/workflows/claude-renovate-review.yaml
+++ b/.github/workflows/claude-renovate-review.yaml
@@ -1,0 +1,68 @@
+---
+## Automated Renovate PR review via Claude Code.
+## Triggers when a PR receives the renovate label, on an hourly schedule
+## (batch triage), or manually via workflow_dispatch. Calls the shared
+## claude-renovate-review workflow from cicd-shared which provides the
+## review skill and claude-code-action infrastructure.
+##
+## Manual testing:
+##   gh workflow run claude-renovate-review.yaml -f pr_number=<PR>
+
+name: claude renovate review
+
+on:
+  pull_request:
+    types: [labeled]
+  schedule:
+    - cron: '0 */4 * * *'
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number to review (for manual testing)'
+        type: string
+        required: true
+
+jobs:
+  resolve-pr:
+    runs-on: ubuntu-latest
+    outputs:
+      pr_number: ${{ steps.resolve.outputs.pr_number }}
+      should_review: ${{ steps.resolve.outputs.should_review }}
+    steps:
+      - name: Resolve PR number and check label
+        id: resolve
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          EVENT_NAME: ${{ github.event_name }}
+          DISPATCH_PR: ${{ inputs.pr_number }}
+          PR_LABEL: ${{ github.event.label.name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+            echo "pr_number=$DISPATCH_PR" >> "$GITHUB_OUTPUT"
+            echo "should_review=true" >> "$GITHUB_OUTPUT"
+          elif [[ "$EVENT_NAME" == "schedule" ]]; then
+            echo "pr_number=" >> "$GITHUB_OUTPUT"
+            echo "should_review=true" >> "$GITHUB_OUTPUT"
+          elif [[ "$PR_LABEL" == "renovate" ]]; then
+            echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+            echo "should_review=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::notice::Label is not renovate -- skipping"
+            echo "pr_number=" >> "$GITHUB_OUTPUT"
+            echo "should_review=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  review:
+    needs: resolve-pr
+    if: ${{ needs.resolve-pr.outputs.should_review == 'true' }}
+    uses: >-
+      verygood-ops/cicd-shared/.github/workflows/claude-renovate-review.yaml@main
+    with:
+      pr_number: ${{ needs.resolve-pr.outputs.pr_number }}
+    secrets:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      VGS_GITHUB_CI_BOT_APP_ID: ${{ secrets.VGS_GITHUB_CI_BOT_APP_ID }}
+      VGS_GITHUB_CI_BOT_APP_PEM_FILE: >-
+        ${{ secrets.VGS_GITHUB_CI_BOT_APP_PEM_FILE }}


### PR DESCRIPTION
## Jira Ticket

<!-- Link Jira ticket here when available -->

## Description of Changes

Adds automated Renovate PR review powered by Claude Code:

- `.github/workflows/claude-renovate-review.yaml` -- triggers on `renovate`
  label, every 4 hours (batch triage), or manual `workflow_dispatch`
- `.claude/references/dependency-map.md` -- repo-specific dependency
  classification for the review skill

The workflow calls the shared `claude-renovate-review` reusable workflow from
`verygood-ops/cicd-shared`, which provides the review skill and
claude-code-action infrastructure.

## Impact

Adds a new GitHub Actions workflow. No changes to existing code or workflows.

## Value Added

Automates risk assessment of Renovate dependency PRs, reducing manual triage
time and accelerating safe dependency updates.

## Accountability

@verygood-ops/team-enablement