### PR TITLE
DEVX-2350: add JavaScript integration skill

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -1,0 +1,26 @@
+# GitHub Contributor Guidance
+
+## Scope
+
+These instructions apply to files under `.github/` and to repository changes that affect public documentation, examples, or committed `skills/` artifacts.
+
+## Public Documentation
+
+- Keep `README.md` focused on customers integrating the package and using public API. Do not add internal implementation details, agent workflow notes, private security triage details, or repo-maintenance process there.
+- Treat `skills/` as public customer integration guidance. Keep committed skill routers, references, and examples accurate against the current source, package metadata, README, and examples.
+- When public API, documented behavior, supported environments, compatibility ranges, or package versions change, update the relevant public skill router, references, and examples in the same change.
+- Back public skill API and version claims with current repo evidence. If a claim cannot be verified, label it as `HYPOTHESIS` and add a TODO instead of presenting it as fact.
+
+## Security
+
+- Keep examples on sandbox and placeholders unless a sanitized customer project already supplies different values.
+- Never put PAN, CVC, SSN, passwords, OAuth tokens, client secrets, production route IDs, production vault IDs, production CNAME details, or bearer tokens in browser examples, screenshots, logs, prompts, or committed skill references.
+- Prefer public integration guidance that preserves VGS Collect secure iframe boundaries.
+
+## Validation Expectations
+
+Before finalizing `.github` changes, confirm:
+
+- Contributor instructions and `README.md` were checked for required updates, with README changes limited to customer-facing public API and integration content.
+- Public `skills/` were checked for required updates when public API, versions, compatibility, setup, examples, or documented behavior changed.
+- Required validation was run, or the blocker was reported.

--- a/.github/workflows/validate-skills.yml
+++ b/.github/workflows/validate-skills.yml
@@ -1,0 +1,36 @@
+name: validate skills
+
+on:
+  pull_request:
+    paths:
+      - 'skills/**'
+  push:
+    paths:
+      - 'skills/**'
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: '3.14'
+
+      - name: Install skills-ref
+        run: python -m pip install --upgrade pip skills-ref
+
+      - name: Validate public JavaScript skill
+        shell: bash
+        run: |
+          set -euo pipefail
+          if ! command -v skills-ref >/dev/null 2>&1 && command -v agentskills >/dev/null 2>&1; then
+            printf '#!/usr/bin/env bash\nexec agentskills "$@"\n' > "$RUNNER_TEMP/skills-ref"
+            chmod +x "$RUNNER_TEMP/skills-ref"
+            export PATH="$RUNNER_TEMP:$PATH"
+          fi
+          skills-ref validate skills/vgs-collect-js-guide

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@
 * [Documentation](#documentation)
 * [Examples](#examples)
 * [Built With](#built-with)
+* [AI Agent Integration](#ai-agent-integration)
 * [Contact](#contact)
 
 ## Overview
@@ -138,6 +139,29 @@ We strongly recommend to add the CSP to your application. Content Security Polic
 
 * [Typescript](https://www.typescriptlang.org/docs/handbook/typescript-in-5-minutes.html)
 * [tsdx template](https://github.com/formium/tsdx)
+
+## AI Agent Integration
+
+This repository ships a public AI skill at [`skills/vgs-collect-js-guide/SKILL.md`](./skills/vgs-collect-js-guide/SKILL.md) for AI agents integrating VGS Collect through vanilla JavaScript, `@vgs/collect-js`, or a direct Collect.js CDN script.
+
+Recommended: install the skill with `skills.sh`. This is the easiest way to give a compatible AI agent the repository-specific guidance it needs for non-React VGS Collect JavaScript integrations.
+
+The installed skill bundle includes loader-specific and direct CDN references and examples. React wrapper guidance for `@vgs/collect-js-react` is packaged separately from this repository skill.
+
+What the skill is useful for:
+
+* integrating VGS Collect through `loadVGSCollect` from `@vgs/collect-js`
+* loading the Collect core SDK from the public CDN when a direct script tag is the right integration path
+* creating secure fields with `VGSCollect.create(...)` or `collect.init(...)`
+* submitting, tokenizing, creating aliases, and configuring common VGS Collect form behavior
+* choosing public Collect core SDK versions without claiming an unverified latest version
+* preserving the secure iframe collection model and avoiding examples that place PAN, CVC, SSN, passwords, OAuth tokens, client secrets, production route IDs, or production CNAME details in browser code
+
+Install the skill with `skills.sh`:
+
+```bash
+npx skills add https://github.com/verygoodsecurity/vgs-collect-js --skill vgs-collect-js-guide
+```
 
 ## Contact
 

--- a/skills/vgs-collect-js-guide/SKILL.md
+++ b/skills/vgs-collect-js-guide/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: vgs-collect-js-guide
-description: Help VGS customers integrate the public VGS Collect JavaScript SDK through @vgs/collect-js or a direct CDN script. Use when users ask to load Collect.js in vanilla JavaScript, use loadVGSCollect, configure window.VGSCollect, create secure fields without React, submit/tokenize VGS Collect forms, choose public Collect CDN versions, or troubleshoot customer-facing non-React Collect integrations.
+description: Help VGS customers integrate, implement, migrate, troubleshoot, or review the public VGS Collect JavaScript SDK through @vgs/collect-js or a direct CDN script. Use when users ask to load Collect.js in vanilla JavaScript, use loadVGSCollect, configure window.VGSCollect, create secure fields without React, submit, tokenize, create aliases, use Collect Session from vanilla JavaScript, choose public Collect CDN versions, or troubleshoot customer-facing non-React Collect integrations.
 metadata:
   author: verygoodsecurity
   version: '1.0.0'
@@ -14,13 +14,52 @@ Use this skill for public customer integration guidance for vanilla JavaScript, 
 
 1. Read `references/javascript.md` for loader setup, direct CDN setup, public form/field APIs, submit/tokenize usage, and examples.
 2. Read `references/compatibility.md` when the answer mentions package installation, Collect core version selection, CDN version selection, or upgrade questions.
-3. Use examples only as copy-paste starting points:
-   - `examples/js-loader/index.js`
-   - `examples/js-cdn/index.html`
+3. Use `examples/js-loader/index.js` only when the selected flow uses the `@vgs/collect-js` loader path.
+4. Use `examples/js-cdn/index.html` only when the selected flow uses the raw CDN script path.
 
 Do not load or answer with React wrapper patterns unless the user explicitly asks for React. If they need `@vgs/collect-js-react`, `VGSCollectSession`, `VGSCollectForm`, React hooks, or React components, use a React wrapper Collect guide instead.
 
-## Version Freshness
+## Task Routing
+
+Choose one primary task mode before answering. The primary mode controls the shape of the output.
+
+- `integrate`: first-time vanilla JavaScript setup. Choose one load path, load Collect core before creating fields, and wire the requested submit flow.
+- `implement`: add or change customer app behavior. Generate code with explicit validation, error handling, and placeholders for secrets, identifiers, endpoints, and environment values the user has not supplied.
+- `migrate`: move between loader, raw CDN, or Collect core versions, or replace direct CDN setup with `@vgs/collect-js`. Compare current and target versions separately for `@vgs/collect-js` and Collect core.
+- `troubleshoot`: localize the failure before changing code. Prefer package state, CDN URL, loader configuration, console errors, network errors, sanitized logs, or a minimal repro.
+- `review`: review code against public JavaScript APIs, selected load path, version evidence, security rules, compatibility, and missing tests. Flag private, deprecated, insecure, or version-incompatible behavior.
+
+## Use-Case Routing
+
+CMP create-card is the primary default, not the only supported use case. First identify the customer's requested load path and submission family, then generate guidance for that flow.
+
+Default to the `@vgs/collect-js` loader path for new vanilla JavaScript examples unless the customer asks for a raw CDN script, already has `window.VGSCollect`, or needs to avoid package installation.
+
+Default to a Card Management Platform create-card integration only when the customer asks for a vanilla JavaScript card form, card entry, add-card, save-card, or payment-method setup and does not name another submission family. Use:
+
+- `loadVGSCollect({ vaultId, environment, version })` followed by `collect.session(...)`, or `VGSCollect.session(...)` for raw CDN script integrations.
+- `formId` for the Collect Session form configured for CMP.
+- `authHandler` that fetches a short-lived access token from the customer's backend.
+- Secure card fields created with `cardholderNameField`, `cardNumberField`, `cardExpirationDateField`, and `cardCVCField`.
+- Required card validations for card number, expiration date, and security code.
+- `form.on('getCardAttributesSuccess', ...)` / `form.on('getCardAttributesError', ...)` when BIN/card-attributes events are useful.
+- `form.createCard(...)` with customer-safe cardholder metadata and success/error callbacks.
+
+Use the requested flow instead when the customer asks for direct CDN script tags, existing `window.VGSCollect`, CMP update-card, proxy submission, vault alias creation, tokenization, custom headers, custom serialization, CNAME, masking, field replacement, non-card fields, file upload, or UI-only field wiring.
+
+## Clarifying Questions
+
+Ask only when the missing information materially changes the recommendation:
+
+- target flow: CMP create-card, CMP update-card, proxy submit, vault aliases, tokenization, Collect Session, or UI-only wiring
+- load path: `@vgs/collect-js`, raw CDN script, or app-provided `window.VGSCollect`
+- installed `@vgs/collect-js` package version or Collect core/CDN version when behavior is version-sensitive
+- target surface: `collect.session(...)`, `VGSCollect.session(...)`, `collect.init(...)`, or `VGSCollect.create(...)`
+- relevant sanitized error, console output, network status, package manifest, lockfile, CDN URL, or code snippet for troubleshooting
+
+## Version And Evidence Policy
+
+Treat the loader package and Collect core as separate versioned surfaces. Do not infer one from another.
 
 When the customer's installed package, CDN script, or requested target version is newer than the versions verified in this skill's references, do not answer from stale bundled guidance alone.
 
@@ -31,9 +70,17 @@ When the customer's installed package, CDN script, or requested target version i
 5. If this skill was installed through `skills.sh`, tell the user they can refresh the local skill with `npx skills check` and `npx skills update <skill-name>` or `npx skills update`.
 6. Do not silently edit or reinstall this skill unless the user explicitly asks for that update.
 
+For version-sensitive answers, state the evidence basis briefly, for example:
+
+- `Using @vgs/collect-js 0.8.0 from package.json; Collect core version was not provided.`
+- `Detected Collect core version <collect_version> from the CDN script URL.`
+- `Could not determine installed loader or Collect core versions; using bundled guidance and marking version-specific claims unverified.`
+
+Retrieve additional evidence only when the task needs exact API signatures, version-specific behavior, concrete error detail, or integration examples. Prefer customer project files first, then public package metadata, README/examples, the public versions endpoint, and official VGS documentation.
+
 ## Customer Safety Rules
 
-- Preserve public API names exactly as documented for customer integrations.
+- Preserve public API names exactly as implemented.
 - If a claim cannot be verified from public package metadata, VGS documentation, the public versions endpoint, or the customer's provided project files, say what must be confirmed instead of inventing an answer.
 - Never ask customers to put PAN, CVC, SSN, passwords, OAuth tokens, client secrets, production route IDs, or production CNAME details in browser code, logs, screenshots, examples, or prompts.
 - Keep sensitive values in placeholders such as `<vault_id>`, `<route_id>`, `<collect_version>`, and `<access_token_from_backend>`.

--- a/skills/vgs-collect-js-guide/SKILL.md
+++ b/skills/vgs-collect-js-guide/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: vgs-collect-js-guide
+description: Help VGS customers integrate the public VGS Collect JavaScript SDK through @vgs/collect-js or a direct CDN script. Use when users ask to load Collect.js in vanilla JavaScript, use loadVGSCollect, configure window.VGSCollect, create secure fields without React, submit/tokenize VGS Collect forms, choose public Collect CDN versions, or troubleshoot customer-facing non-React Collect integrations.
+metadata:
+  author: verygoodsecurity
+  version: '1.0.0'
+---
+
+# VGS Collect JS Guide
+
+Use this skill for public customer integration guidance for vanilla JavaScript, `@vgs/collect-js`, and direct Collect.js CDN script usage only. Keep answers and bundled references limited to public JavaScript APIs, public CDN usage, examples, and troubleshooting.
+
+## Route First
+
+1. Read `references/javascript.md` for loader setup, direct CDN setup, public form/field APIs, submit/tokenize usage, and examples.
+2. Read `references/compatibility.md` when the answer mentions package installation, Collect core version selection, CDN version selection, or upgrade questions.
+3. Use examples only as copy-paste starting points:
+   - `examples/js-loader/index.js`
+   - `examples/js-cdn/index.html`
+
+Do not load or answer with React wrapper patterns unless the user explicitly asks for React. If they need `@vgs/collect-js-react`, `VGSCollectSession`, `VGSCollectForm`, React hooks, or React components, use a React wrapper Collect guide instead.
+
+## Version Freshness
+
+When the customer's installed package, CDN script, or requested target version is newer than the versions verified in this skill's references, do not answer from stale bundled guidance alone.
+
+1. Read `references/compatibility.md`.
+2. Check `https://js.verygoodvault.com/versions/vgs_collect.json` when the answer needs public vanilla Collect CDN/core versions.
+3. Inspect the customer's current `package.json`, lockfile, CDN URL, and provided code before making version-specific claims.
+4. If current evidence is still unavailable, label the version-specific claim as unverified and ask the customer to confirm it from VGS documentation, public package metadata, or the versions endpoint.
+5. If this skill was installed through `skills.sh`, tell the user they can refresh the local skill with `npx skills check` and `npx skills update <skill-name>` or `npx skills update`.
+6. Do not silently edit or reinstall this skill unless the user explicitly asks for that update.
+
+## Customer Safety Rules
+
+- Preserve public API names exactly as documented for customer integrations.
+- If a claim cannot be verified from public package metadata, VGS documentation, the public versions endpoint, or the customer's provided project files, say what must be confirmed instead of inventing an answer.
+- Never ask customers to put PAN, CVC, SSN, passwords, OAuth tokens, client secrets, production route IDs, or production CNAME details in browser code, logs, screenshots, examples, or prompts.
+- Keep sensitive values in placeholders such as `<vault_id>`, `<route_id>`, `<collect_version>`, and `<access_token_from_backend>`.

--- a/skills/vgs-collect-js-guide/examples/js-cdn/index.html
+++ b/skills/vgs-collect-js-guide/examples/js-cdn/index.html
@@ -15,48 +15,105 @@
     </form>
 
     <script>
-      const form = VGSCollect.create('<vault_id>', 'sandbox', function (state) {
-        console.log(state);
-      });
+      (async function () {
+        const cmpConfiguration = {
+          cardAttributes: {
+            enable: true,
+            parameters: ['card_brand', 'card_type', 'product_name']
+          }
+        };
 
-      form.field('#card-name', {
-        type: 'text',
-        name: 'card_name',
-        validations: ['required'],
-        placeholder: 'Name on card'
-      });
+        async function getAccessToken() {
+          const response = await fetch('/api/access-token');
+          const data = await response.json();
 
-      form.field('#card-number', {
-        type: 'card-number',
-        name: 'card_number',
-        validations: ['required', 'validCardNumber'],
-        placeholder: 'Card number'
-      });
+          if (!response.ok || typeof data.access_token !== 'string') {
+            throw new Error(data.error_description || data.error || 'Failed to fetch access token');
+          }
 
-      form.field('#card-expiration', {
-        type: 'card-expiration-date',
-        name: 'card_expiration',
-        validations: ['required', 'validCardExpirationDate'],
-        yearLength: 2,
-        placeholder: 'MM/YY'
-      });
-
-      form.field('#card-cvc', {
-        type: 'card-security-code',
-        name: 'card_cvc',
-        validations: ['required', 'validCardSecurityCode'],
-        placeholder: 'CVC'
-      });
-
-      document.querySelector('#payment-form').addEventListener('submit', async function (event) {
-        event.preventDefault();
-        try {
-          const result = await form.submit('/post', { serialization: 'formData' });
-          console.log(result.status, result.data);
-        } catch (errors) {
-          console.log(errors);
+          return data.access_token;
         }
-      });
+
+        function handleFormState(state) {
+          void state;
+          // Map validity and error state to customer-safe UI; do not log sensitive field state.
+        }
+
+        function handleCreateCardSuccess(status, data) {
+          void status;
+          void data;
+          // Store card IDs or other non-sensitive response values needed by the app.
+        }
+
+        function handleCreateCardError(errors) {
+          void errors;
+          // Map validation/session errors to customer-safe UI messages.
+        }
+
+        const form = await VGSCollect.session({
+          vaultId: '<vault_id>',
+          env: 'sandbox',
+          formId: '<collect_form_id>',
+          configuration: cmpConfiguration,
+          stateCallback: handleFormState,
+          authHandler: getAccessToken,
+          onErrorCallback: handleCreateCardError
+        });
+
+        form.on('getCardAttributesSuccess', function (response) {
+          void response;
+          // Use card brand/type/product metadata for UI only; do not log sensitive input.
+        });
+
+        form.on('getCardAttributesError', function (errors) {
+          void errors;
+        });
+
+        form.cardholderNameField('#card-name', {
+          placeholder: 'Name on card'
+        });
+
+        form.cardNumberField('#card-number', {
+          validations: ['required', 'validCardNumber'],
+          placeholder: 'Card number'
+        });
+
+        form.cardExpirationDateField('#card-expiration', {
+          validations: ['required', 'validCardExpirationDate'],
+          yearLength: 2,
+          placeholder: 'MM/YY'
+        });
+
+        form.cardCVCField('#card-cvc', {
+          validations: ['required', 'validCardSecurityCode'],
+          placeholder: 'CVC'
+        });
+
+        document.querySelector('#payment-form').addEventListener('submit', async function (event) {
+          event.preventDefault();
+          try {
+            await form.createCard(
+              {
+                data: {
+                  cardholder: {
+                    address: {
+                      address1: '123 Main St',
+                      city: 'LA',
+                      region: 'CA',
+                      postal_code: '12345',
+                      country: 'USA'
+                    }
+                  }
+                }
+              },
+              handleCreateCardSuccess,
+              handleCreateCardError
+            );
+          } catch (errors) {
+            handleCreateCardError(errors);
+          }
+        });
+      })();
     </script>
   </body>
 </html>

--- a/skills/vgs-collect-js-guide/examples/js-cdn/index.html
+++ b/skills/vgs-collect-js-guide/examples/js-cdn/index.html
@@ -1,0 +1,62 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>VGS Collect CDN Example</title>
+    <script src="https://js.verygoodvault.com/vgs-collect/<collect_version>/vgs-collect.js"></script>
+  </head>
+  <body>
+    <form id="payment-form">
+      <label>Name on card <span id="card-name"></span></label>
+      <label>Card number <span id="card-number"></span></label>
+      <label>Expiration date <span id="card-expiration"></span></label>
+      <label>CVC <span id="card-cvc"></span></label>
+      <button type="submit">Submit</button>
+    </form>
+
+    <script>
+      const form = VGSCollect.create('<vault_id>', 'sandbox', function (state) {
+        console.log(state);
+      });
+
+      form.field('#card-name', {
+        type: 'text',
+        name: 'card_name',
+        validations: ['required'],
+        placeholder: 'Name on card'
+      });
+
+      form.field('#card-number', {
+        type: 'card-number',
+        name: 'card_number',
+        validations: ['required', 'validCardNumber'],
+        placeholder: 'Card number'
+      });
+
+      form.field('#card-expiration', {
+        type: 'card-expiration-date',
+        name: 'card_expiration',
+        validations: ['required', 'validCardExpirationDate'],
+        yearLength: 2,
+        placeholder: 'MM/YY'
+      });
+
+      form.field('#card-cvc', {
+        type: 'card-security-code',
+        name: 'card_cvc',
+        validations: ['required', 'validCardSecurityCode'],
+        placeholder: 'CVC'
+      });
+
+      document.querySelector('#payment-form').addEventListener('submit', async function (event) {
+        event.preventDefault();
+        try {
+          const result = await form.submit('/post', { serialization: 'formData' });
+          console.log(result.status, result.data);
+        } catch (errors) {
+          console.log(errors);
+        }
+      });
+    </script>
+  </body>
+</html>

--- a/skills/vgs-collect-js-guide/examples/js-loader/index.js
+++ b/skills/vgs-collect-js-guide/examples/js-loader/index.js
@@ -1,40 +1,80 @@
 import { loadVGSCollect } from '@vgs/collect-js';
 
+const cmpConfiguration = {
+  cardAttributes: {
+    enable: true,
+    parameters: ['card_brand', 'card_type', 'product_name']
+  }
+};
+
+async function getAccessToken() {
+  const response = await fetch('/api/access-token');
+  const data = await response.json();
+
+  if (!response.ok || typeof data.access_token !== 'string') {
+    throw new Error(data.error_description || data.error || 'Failed to fetch access token');
+  }
+
+  return data.access_token;
+}
+
+function handleFormState(state) {
+  void state;
+  // Map validity and error state to customer-safe UI; do not log sensitive field state.
+}
+
+function handleCreateCardSuccess(status, data) {
+  void status;
+  void data;
+  // Store card IDs or other non-sensitive response values needed by the app.
+}
+
+function handleCreateCardError(errors) {
+  void errors;
+  // Map validation/session errors to customer-safe UI messages.
+}
+
 const collect = await loadVGSCollect({
   vaultId: '<vault_id>',
   environment: 'sandbox',
   version: '<collect_version>'
 });
 
-const form = collect.init((state) => {
-  console.log(state);
+const form = await collect.session({
+  vaultId: '<vault_id>',
+  env: 'sandbox',
+  formId: '<collect_form_id>',
+  configuration: cmpConfiguration,
+  stateCallback: handleFormState,
+  authHandler: getAccessToken,
+  onErrorCallback: handleCreateCardError
 });
 
-form.field('#card-name', {
-  type: 'text',
-  name: 'card_name',
-  validations: ['required'],
+form.on('getCardAttributesSuccess', (response) => {
+  void response;
+  // Use card brand/type/product metadata for UI only; do not log sensitive input.
+});
+
+form.on('getCardAttributesError', (errors) => {
+  void errors;
+});
+
+form.cardholderNameField('#card-name', {
   placeholder: 'Name on card'
 });
 
-form.field('#card-number', {
-  type: 'card-number',
-  name: 'card_number',
+form.cardNumberField('#card-number', {
   validations: ['required', 'validCardNumber'],
   placeholder: 'Card number'
 });
 
-form.field('#card-expiration', {
-  type: 'card-expiration-date',
-  name: 'card_expiration',
+form.cardExpirationDateField('#card-expiration', {
   validations: ['required', 'validCardExpirationDate'],
   yearLength: 2,
   placeholder: 'MM/YY'
 });
 
-form.field('#card-cvc', {
-  type: 'card-security-code',
-  name: 'card_cvc',
+form.cardCVCField('#card-cvc', {
   validations: ['required', 'validCardSecurityCode'],
   placeholder: 'CVC'
 });
@@ -43,11 +83,24 @@ document.querySelector('#payment-form').addEventListener('submit', async (event)
   event.preventDefault();
 
   try {
-    const result = await form.submit('/post', {
-      serialization: 'formData'
-    });
-    console.log(result.status, result.data);
+    await form.createCard(
+      {
+        data: {
+          cardholder: {
+            address: {
+              address1: '123 Main St',
+              city: 'LA',
+              region: 'CA',
+              postal_code: '12345',
+              country: 'USA'
+            }
+          }
+        }
+      },
+      handleCreateCardSuccess,
+      handleCreateCardError
+    );
   } catch (errors) {
-    console.log(errors);
+    handleCreateCardError(errors);
   }
 });

--- a/skills/vgs-collect-js-guide/examples/js-loader/index.js
+++ b/skills/vgs-collect-js-guide/examples/js-loader/index.js
@@ -1,0 +1,53 @@
+import { loadVGSCollect } from '@vgs/collect-js';
+
+const collect = await loadVGSCollect({
+  vaultId: '<vault_id>',
+  environment: 'sandbox',
+  version: '<collect_version>'
+});
+
+const form = collect.init((state) => {
+  console.log(state);
+});
+
+form.field('#card-name', {
+  type: 'text',
+  name: 'card_name',
+  validations: ['required'],
+  placeholder: 'Name on card'
+});
+
+form.field('#card-number', {
+  type: 'card-number',
+  name: 'card_number',
+  validations: ['required', 'validCardNumber'],
+  placeholder: 'Card number'
+});
+
+form.field('#card-expiration', {
+  type: 'card-expiration-date',
+  name: 'card_expiration',
+  validations: ['required', 'validCardExpirationDate'],
+  yearLength: 2,
+  placeholder: 'MM/YY'
+});
+
+form.field('#card-cvc', {
+  type: 'card-security-code',
+  name: 'card_cvc',
+  validations: ['required', 'validCardSecurityCode'],
+  placeholder: 'CVC'
+});
+
+document.querySelector('#payment-form').addEventListener('submit', async (event) => {
+  event.preventDefault();
+
+  try {
+    const result = await form.submit('/post', {
+      serialization: 'formData'
+    });
+    console.log(result.status, result.data);
+  } catch (errors) {
+    console.log(errors);
+  }
+});

--- a/skills/vgs-collect-js-guide/references/compatibility.md
+++ b/skills/vgs-collect-js-guide/references/compatibility.md
@@ -6,8 +6,23 @@ Use this reference for package installation, version selection, loader/core comp
 
 - Do not claim a package or CDN version is latest unless it was verified from current public package or documentation metadata.
 - Do not infer the loader package version from the Collect core version.
+- Do not infer the Collect core version from the loader package version.
 - For production, use an explicit pinned Collect core version.
 - When troubleshooting, prefer the versions already pinned in the customer's package manager files, environment variables, and CDN script URLs.
+
+## Installation Shape
+
+For package-based vanilla JavaScript integrations, install the loader package:
+
+```bash
+npm install @vgs/collect-js
+```
+
+For raw CDN integrations, no npm package is required. The customer must include a pinned Collect core script:
+
+```html
+<script src="https://js.verygoodvault.com/vgs-collect/<collect_version>/vgs-collect.js"></script>
+```
 
 ## Version Source
 
@@ -33,9 +48,20 @@ Use `tags.stable` and the `versions` list from that endpoint as the public sourc
 - If the customer asks which exact version to install or pin, verify the current package/CDN version first.
 - If verification is unavailable, explain the rule: pin a concrete production version and confirm the target version from VGS docs, package metadata, the public versions endpoint, or the customer's existing project config.
 - For vanilla JavaScript apps, choose either the loader package or the raw CDN script path.
+- The loader package can load a configured Collect core version; production examples should pass `version: '<collect_version>'` instead of relying on loader defaults.
+
+## Load Path Compatibility
+
+- Use the loader path when the app already has a bundler, package manager, or framework-agnostic module setup.
+- Use the raw CDN path when the app cannot install npm packages or already manages browser scripts directly.
+- Use only one load path on a page unless the customer has a deliberate script-loading strategy.
+- If `window.VGSCollect` already exists, `loadVGSCollect(...)` resolves with that runtime and initializes the convenience `init(...)` wrapper with the supplied vault, environment, and log-level config.
+- If Content Security Policy is in scope, include the VGS script and connection domains required by the customer's selected environment and route setup.
 
 ## Upgrade Guidance
 
 - Ask for the customer's current package versions, Collect core version, CDN script URL, and relevant console errors.
 - Upgrade one layer at a time when possible: loader and core SDK are separate versioned surfaces.
+- For loader-path changes, verify `@vgs/collect-js` package metadata and the configured `version` passed to `loadVGSCollect(...)`.
+- For raw CDN changes, verify the script URL and the public versions endpoint.
 - Keep customer examples on sandbox and placeholders unless the user provides sanitized project config.

--- a/skills/vgs-collect-js-guide/references/compatibility.md
+++ b/skills/vgs-collect-js-guide/references/compatibility.md
@@ -1,0 +1,41 @@
+# Compatibility
+
+Use this reference for package installation, version selection, loader/core compatibility, CDN version selection, and upgrade questions.
+
+## Customer-Safe Rules
+
+- Do not claim a package or CDN version is latest unless it was verified from current public package or documentation metadata.
+- Do not infer the loader package version from the Collect core version.
+- For production, use an explicit pinned Collect core version.
+- When troubleshooting, prefer the versions already pinned in the customer's package manager files, environment variables, and CDN script URLs.
+
+## Version Source
+
+When vanilla Collect CDN/core versions are required, check:
+
+```txt
+https://js.verygoodvault.com/versions/vgs_collect.json
+```
+
+Use `tags.stable` and the `versions` list from that endpoint as the public source for available Collect versions. Do not hardcode or claim a current version without checking the endpoint at answer time.
+
+## Package Roles
+
+| Layer | Customer-facing purpose | Versioning guidance |
+| --- | --- | --- |
+| `@vgs/collect-js` | Browser script loader that loads the Collect core SDK from the CDN. | Version separately from the Collect core SDK. It accepts a configured core SDK version. |
+| Collect core SDK | Browser runtime exposed as `window.VGSCollect`. | Pin a concrete CDN/core version for production. Use the customer's existing pinned version when diagnosing behavior. |
+| Raw CDN script | Direct browser script tag without the loader package. | Use `https://js.verygoodvault.com/vgs-collect/<collect_version>/vgs-collect.js` with a verified version. |
+
+## Version Selection
+
+- Use `<collect_version>` as a placeholder in examples unless the customer provided a verified target version.
+- If the customer asks which exact version to install or pin, verify the current package/CDN version first.
+- If verification is unavailable, explain the rule: pin a concrete production version and confirm the target version from VGS docs, package metadata, the public versions endpoint, or the customer's existing project config.
+- For vanilla JavaScript apps, choose either the loader package or the raw CDN script path.
+
+## Upgrade Guidance
+
+- Ask for the customer's current package versions, Collect core version, CDN script URL, and relevant console errors.
+- Upgrade one layer at a time when possible: loader and core SDK are separate versioned surfaces.
+- Keep customer examples on sandbox and placeholders unless the user provides sanitized project config.

--- a/skills/vgs-collect-js-guide/references/javascript.md
+++ b/skills/vgs-collect-js-guide/references/javascript.md
@@ -1,0 +1,214 @@
+# JavaScript Integration
+
+Use this reference for customers integrating VGS Collect in vanilla JavaScript, framework-agnostic browser apps, or apps that want to load VGS Collect without the React wrapper.
+
+## Contents
+
+- Choose One Load Path
+- Loader Path
+- Raw CDN Path
+- Loader API
+- Core/CDN API
+- Form And Field API
+- Submit Behavior
+
+## Choose One Load Path
+
+Vanilla JS has two public load sub-paths:
+
+1. Loader package: import `loadVGSCollect` from `@vgs/collect-js`, then create a form after the loader resolves.
+2. Raw CDN script: include `https://js.verygoodvault.com/vgs-collect/<collect_version>/vgs-collect.js`, then use `window.VGSCollect.create(...)`.
+
+Use one load path per page unless the customer's app already has a deliberate script-loading strategy.
+
+## Loader Path
+
+```js
+import { loadVGSCollect } from '@vgs/collect-js';
+
+const collect = await loadVGSCollect({
+  vaultId: '<vault_id>',
+  environment: 'sandbox',
+  version: '<collect_version>'
+});
+
+const form = collect.init((state) => {
+  console.log(state);
+});
+
+form.field('#card-name', {
+  type: 'text',
+  name: 'card_name',
+  validations: ['required'],
+  placeholder: 'Name on card'
+});
+
+form.field('#card-number', {
+  type: 'card-number',
+  name: 'card_number',
+  validations: ['required', 'validCardNumber'],
+  placeholder: 'Card number'
+});
+
+form.field('#card-expiration', {
+  type: 'card-expiration-date',
+  name: 'card_expiration',
+  validations: ['required', 'validCardExpirationDate'],
+  yearLength: 2,
+  placeholder: 'MM/YY'
+});
+
+form.field('#card-cvc', {
+  type: 'card-security-code',
+  name: 'card_cvc',
+  validations: ['required', 'validCardSecurityCode'],
+  placeholder: 'CVC'
+});
+
+document.querySelector('#payment-form').addEventListener('submit', async (event) => {
+  event.preventDefault();
+
+  try {
+    const result = await form.submit('/post', {
+      serialization: 'formData'
+    });
+    console.log(result.status, result.data);
+  } catch (errors) {
+    console.log(errors);
+  }
+});
+```
+
+## Raw CDN Path
+
+```html
+<form id="payment-form">
+  <div id="card-name"></div>
+  <div id="card-number"></div>
+  <div id="card-expiration"></div>
+  <div id="card-cvc"></div>
+  <button type="submit">Submit</button>
+</form>
+
+<script src="https://js.verygoodvault.com/vgs-collect/<collect_version>/vgs-collect.js"></script>
+<script>
+  const form = VGSCollect.create('<vault_id>', 'sandbox', function (state) {
+    console.log(state);
+  });
+
+  form.field('#card-name', {
+    type: 'text',
+    name: 'card_name',
+    validations: ['required'],
+    placeholder: 'Name on card'
+  });
+
+  form.field('#card-number', {
+    type: 'card-number',
+    name: 'card_number',
+    validations: ['required', 'validCardNumber'],
+    placeholder: 'Card number'
+  });
+
+  form.field('#card-expiration', {
+    type: 'card-expiration-date',
+    name: 'card_expiration',
+    validations: ['required', 'validCardExpirationDate'],
+    yearLength: 2,
+    placeholder: 'MM/YY'
+  });
+
+  form.field('#card-cvc', {
+    type: 'card-security-code',
+    name: 'card_cvc',
+    validations: ['required', 'validCardSecurityCode'],
+    placeholder: 'CVC'
+  });
+
+  document.querySelector('#payment-form').addEventListener('submit', async function (event) {
+    event.preventDefault();
+    try {
+      const result = await form.submit('/post', { serialization: 'formData' });
+      console.log(result.status, result.data);
+    } catch (errors) {
+      console.log(errors);
+    }
+  });
+</script>
+```
+
+## Loader API
+
+Use this section for customers who import from `@vgs/collect-js`.
+
+`loadVGSCollect(config)` accepts:
+
+- `vaultId`: required vault ID, represented as `<vault_id>` in examples.
+- `environment`: optional environment; use `sandbox` in examples.
+- `version`: optional Collect core SDK version; production integrations should pin an explicit public version.
+- `integrity`: optional script integrity value.
+- `crossorigin`: optional script cross-origin setting.
+
+`loadVGSCollect(config)` resolves to the loaded Collect instance. After it resolves, call `collect.init(stateCallback)` to create a form for manual field setup.
+
+## Core/CDN API
+
+Use this section for customers who load the raw CDN script or already have `window.VGSCollect` available.
+
+`VGSCollect` methods commonly used in customer integrations:
+
+- `create(tntId, environment = 'sandbox', onUpdateCallback)`
+- `session(options)`
+- `load(modulesList)`
+- `logLevel('none' | 'default')`
+- `emit(eventName, ...args)`
+- `subscribe(eventName, callback)`
+
+Use `VGSCollect.create(...)` for direct/manual field setup. Use `VGSCollect.session(...)` when the customer has a Collect Session form ID, CMP/Card Attributes configuration, or authenticated session behavior.
+
+## Form And Field API
+
+Common form methods:
+
+- `useCname(cname)`
+- `setRouteId(routeId)`
+- `setAuthToken(token)`
+- `field(selector, properties)`
+- `reset()`
+- `submit(path, options, onSuccess?, onFailure?)`
+- `tokenize(onSuccess?, onError?)`
+- `createAliases(params, onSuccess?, onError?)`
+- `createCard(parameters, onSuccess?, onError?)`
+- `updateCard(parameters, onSuccess?, onError?)`
+- `on(event, callback)`
+- `off(event, callback)`
+- `unmount()`
+
+Common field methods:
+
+- `on(eventType, callback)`
+- `off(eventType, callback)`
+- `delete()`
+- `mask(mask, maskChar?, formatChars?)` or `mask({ mask, maskChar, formatChars, hideValue })`
+- `replacePattern(regExpString, newSubStr?)`
+- `focus()`
+- `prefill()`
+- `reset()`
+- `update(params)`
+
+Common field types include `card-number`, `card-expiration-date`, `card-security-code`, `zip-code`, `postal-code`, `file`, `ssn`, `checkbox`, `dropdown`, `password`, `number`, `radio`, `textarea`, `text`, and `date`.
+
+Common validations include `required`, `validCardNumber`, `validCardExpirationDate`, `validCardSecurityCode`, `validSSN`, `validABARoutingNumber`, `compareValue`, `compareDate`, postal code validations, and regex validations written as `/pattern/flags`.
+
+## Submit Behavior
+
+`form.submit(path, options, success?, failure?)` supports callbacks and promises. A successful submit resolves `{ status, data }`; validation errors reject with the form state payload passed to the failure callback.
+
+Common submit options:
+
+- `data`: object or function.
+- `headers`: object or async function.
+- `method`: HTTP method.
+- `serialization`: default JSON-like object, or `formData`.
+- `mapDotToObject`: false by default; `true`, `merge`, or `mergeArray` shape nested field names and additional data.
+- `withCredentials`: false by default.

--- a/skills/vgs-collect-js-guide/references/javascript.md
+++ b/skills/vgs-collect-js-guide/references/javascript.md
@@ -4,27 +4,107 @@ Use this reference for customers integrating VGS Collect in vanilla JavaScript, 
 
 ## Contents
 
+- Installation Shape
 - Choose One Load Path
+- Load Order
+- Flow Selection
+- Default CMP Create-Card Pattern
 - Loader Path
 - Raw CDN Path
 - Loader API
 - Core/CDN API
 - Form And Field API
-- Submit Behavior
+- Submit Modes
+- Events And State
+- Masking And Field Transforms
+- CMP And Session Notes
+
+## Installation Shape
+
+Install the loader package when the app uses a package manager or bundler:
+
+```bash
+npm install @vgs/collect-js
+```
+
+Use the raw CDN script when the app cannot install npm packages or already manages browser scripts directly.
 
 ## Choose One Load Path
 
 Vanilla JS has two public load sub-paths:
 
 1. Loader package: import `loadVGSCollect` from `@vgs/collect-js`, then create a form after the loader resolves.
-2. Raw CDN script: include `https://js.verygoodvault.com/vgs-collect/<collect_version>/vgs-collect.js`, then use `window.VGSCollect.create(...)`.
+2. Raw CDN script: include `https://js.verygoodvault.com/vgs-collect/<collect_version>/vgs-collect.js`, then use `window.VGSCollect.session(...)` for CMP or `window.VGSCollect.create(...)` for manual flows.
 
 Use one load path per page unless the customer's app already has a deliberate script-loading strategy.
 
-## Loader Path
+## Load Order
+
+1. Load Collect core with `loadVGSCollect(...)` or a raw CDN script.
+2. Create the form only after Collect core is available.
+3. Render VGS fields into stable DOM containers.
+4. Validate field state before create-card, submit, or tokenization when the app controls the submit button.
+5. Send only aliases, tokens, card IDs, or other non-sensitive response values to the app layer.
+
+## Flow Selection
+
+Start every integration answer by choosing the customer's load path and submit family. CMP create-card is the default for ambiguous card-management work, but this reference must still guide other vanilla JavaScript use cases when requested. The loader path is the default for new vanilla JavaScript examples, but direct CDN remains supported when requested.
+
+| Customer request | Recommended JavaScript path |
+| --- | --- |
+| Add, save, or create a card/payment method and no other submission family is named | `@vgs/collect-js` with `collect.session(...)` and `form.createCard(...)` |
+| Existing script-tag app or no package manager | Raw CDN script with `VGSCollect.session(...)` for CMP, or `VGSCollect.create(...)` for manual flows |
+| Existing `window.VGSCollect` runtime | Use the existing runtime; do not add another script unless the customer asks to migrate |
+| Submit collected values through a VGS route | `form.submit(path, options, success?, failure?)` |
+| Create aliases directly | `form.createAliases(params, onSuccess?, onError?)` |
+| Tokenize fields | `form.tokenize(onSuccess?, onError?)` |
+| CMP create-card without React | `VGSCollect.session(...)` or loader-returned `collect.session(...)`, then `form.createCard(...)` |
+| CMP update-card without React | `VGSCollect.session(...)` or loader-returned `collect.session(...)`, then `form.updateCard(...)` |
+| Style fields, handle events, mask supported fields, or wire UI only | Render fields and callbacks for that task; do not force a submit flow |
+| Collect SSN, passwords, files, routing numbers, dates, or generic non-card data | Use matching field types and the requested proxy/vault/tokenization flow; do not use a card-specific default |
+
+If the request is ambiguous but appears to be generic secure collection rather than card creation, ask which submission family they need instead of forcing CMP.
+
+## Default CMP Create-Card Pattern
+
+Use this pattern by default when the customer asks for a vanilla JavaScript card form, payment form, card entry, add-card, save-card, or payment-method setup and does not name another submission family.
 
 ```js
 import { loadVGSCollect } from '@vgs/collect-js';
+
+const cmpConfiguration = {
+  cardAttributes: {
+    enable: true,
+    parameters: ['card_brand', 'card_type', 'product_name']
+  }
+};
+
+async function getAccessToken() {
+  const response = await fetch('/api/access-token');
+  const data = await response.json();
+
+  if (!response.ok || typeof data.access_token !== 'string') {
+    throw new Error(data.error_description || data.error || 'Failed to fetch access token');
+  }
+
+  return data.access_token;
+}
+
+function handleFormState(state) {
+  void state;
+  // Map validity and error state to customer-safe UI; do not log sensitive field state.
+}
+
+function handleCreateCardSuccess(status, data) {
+  void status;
+  void data;
+  // Store card IDs or other non-sensitive response values needed by the app.
+}
+
+function handleCreateCardError(errors) {
+  void errors;
+  // Map validation/session errors to customer-safe UI messages.
+}
 
 const collect = await loadVGSCollect({
   vaultId: '<vault_id>',
@@ -32,35 +112,41 @@ const collect = await loadVGSCollect({
   version: '<collect_version>'
 });
 
-const form = collect.init((state) => {
-  console.log(state);
+const form = await collect.session({
+  vaultId: '<vault_id>',
+  env: 'sandbox',
+  formId: '<collect_form_id>',
+  configuration: cmpConfiguration,
+  stateCallback: handleFormState,
+  authHandler: getAccessToken,
+  onErrorCallback: handleCreateCardError
 });
 
-form.field('#card-name', {
-  type: 'text',
-  name: 'card_name',
-  validations: ['required'],
+form.on('getCardAttributesSuccess', (response) => {
+  void response;
+  // Use card brand/type/product metadata for UI only; do not log sensitive input.
+});
+
+form.on('getCardAttributesError', (errors) => {
+  void errors;
+});
+
+form.cardholderNameField('#card-name', {
   placeholder: 'Name on card'
 });
 
-form.field('#card-number', {
-  type: 'card-number',
-  name: 'card_number',
+form.cardNumberField('#card-number', {
   validations: ['required', 'validCardNumber'],
   placeholder: 'Card number'
 });
 
-form.field('#card-expiration', {
-  type: 'card-expiration-date',
-  name: 'card_expiration',
+form.cardExpirationDateField('#card-expiration', {
   validations: ['required', 'validCardExpirationDate'],
   yearLength: 2,
   placeholder: 'MM/YY'
 });
 
-form.field('#card-cvc', {
-  type: 'card-security-code',
-  name: 'card_cvc',
+form.cardCVCField('#card-cvc', {
   validations: ['required', 'validCardSecurityCode'],
   placeholder: 'CVC'
 });
@@ -69,17 +155,46 @@ document.querySelector('#payment-form').addEventListener('submit', async (event)
   event.preventDefault();
 
   try {
-    const result = await form.submit('/post', {
-      serialization: 'formData'
-    });
-    console.log(result.status, result.data);
+    await form.createCard(
+      {
+        data: {
+          cardholder: {
+            address: {
+              address1: '123 Main St',
+              city: 'LA',
+              region: 'CA',
+              postal_code: '12345',
+              country: 'USA'
+            }
+          }
+        }
+      },
+      handleCreateCardSuccess,
+      handleCreateCardError
+    );
   } catch (errors) {
-    console.log(errors);
+    handleCreateCardError(errors);
   }
 });
 ```
 
+## Loader Path
+
+Use this path when the app imports from `@vgs/collect-js`.
+
+- Import `loadVGSCollect`.
+- Pass `vaultId`, `environment`, and a pinned `version`.
+- Wait for the promise to resolve.
+- Call `collect.session(options)` for the default CMP create-card flow.
+- Call `collect.init(stateCallback)` only for direct/manual field setup such as proxy submit, aliases, tokenization, or UI-only wiring.
+- Create fields with CMP preset helpers or `form.field(selector, properties)`, depending on the requested flow.
+- Create cards, submit, tokenize, or create aliases with the form method that matches the requested flow.
+
+Use `examples/js-loader/index.js` as the copy-paste starting point for this path.
+
 ## Raw CDN Path
+
+Use this path when the app loads Collect core directly with a script tag or already has `window.VGSCollect`.
 
 ```html
 <form id="payment-form">
@@ -92,50 +207,109 @@ document.querySelector('#payment-form').addEventListener('submit', async (event)
 
 <script src="https://js.verygoodvault.com/vgs-collect/<collect_version>/vgs-collect.js"></script>
 <script>
-  const form = VGSCollect.create('<vault_id>', 'sandbox', function (state) {
-    console.log(state);
-  });
+  (async function () {
+    const cmpConfiguration = {
+      cardAttributes: {
+        enable: true,
+        parameters: ['card_brand', 'card_type', 'product_name']
+      }
+    };
 
-  form.field('#card-name', {
-    type: 'text',
-    name: 'card_name',
-    validations: ['required'],
-    placeholder: 'Name on card'
-  });
+    async function getAccessToken() {
+      const response = await fetch('/api/access-token');
+      const data = await response.json();
 
-  form.field('#card-number', {
-    type: 'card-number',
-    name: 'card_number',
-    validations: ['required', 'validCardNumber'],
-    placeholder: 'Card number'
-  });
+      if (!response.ok || typeof data.access_token !== 'string') {
+        throw new Error(data.error_description || data.error || 'Failed to fetch access token');
+      }
 
-  form.field('#card-expiration', {
-    type: 'card-expiration-date',
-    name: 'card_expiration',
-    validations: ['required', 'validCardExpirationDate'],
-    yearLength: 2,
-    placeholder: 'MM/YY'
-  });
-
-  form.field('#card-cvc', {
-    type: 'card-security-code',
-    name: 'card_cvc',
-    validations: ['required', 'validCardSecurityCode'],
-    placeholder: 'CVC'
-  });
-
-  document.querySelector('#payment-form').addEventListener('submit', async function (event) {
-    event.preventDefault();
-    try {
-      const result = await form.submit('/post', { serialization: 'formData' });
-      console.log(result.status, result.data);
-    } catch (errors) {
-      console.log(errors);
+      return data.access_token;
     }
-  });
+
+    function handleFormState(state) {
+      void state;
+      // Map validity and error state to customer-safe UI; do not log sensitive field state.
+    }
+
+    function handleCreateCardSuccess(status, data) {
+      void status;
+      void data;
+      // Store card IDs or other non-sensitive response values needed by the app.
+    }
+
+    function handleCreateCardError(errors) {
+      void errors;
+      // Map validation/session errors to customer-safe UI messages.
+    }
+
+    const form = await VGSCollect.session({
+      vaultId: '<vault_id>',
+      env: 'sandbox',
+      formId: '<collect_form_id>',
+      configuration: cmpConfiguration,
+      stateCallback: handleFormState,
+      authHandler: getAccessToken,
+      onErrorCallback: handleCreateCardError
+    });
+
+    form.on('getCardAttributesSuccess', function (response) {
+      void response;
+      // Use card brand/type/product metadata for UI only; do not log sensitive input.
+    });
+
+    form.on('getCardAttributesError', function (errors) {
+      void errors;
+    });
+
+    form.cardholderNameField('#card-name', {
+      placeholder: 'Name on card'
+    });
+
+    form.cardNumberField('#card-number', {
+      validations: ['required', 'validCardNumber'],
+      placeholder: 'Card number'
+    });
+
+    form.cardExpirationDateField('#card-expiration', {
+      validations: ['required', 'validCardExpirationDate'],
+      yearLength: 2,
+      placeholder: 'MM/YY'
+    });
+
+    form.cardCVCField('#card-cvc', {
+      validations: ['required', 'validCardSecurityCode'],
+      placeholder: 'CVC'
+    });
+
+    document.querySelector('#payment-form').addEventListener('submit', async function (event) {
+      event.preventDefault();
+      try {
+        await form.createCard(
+          {
+            data: {
+              cardholder: {
+                address: {
+                  address1: '123 Main St',
+                  city: 'LA',
+                  region: 'CA',
+                  postal_code: '12345',
+                  country: 'USA'
+                }
+              }
+            }
+          },
+          handleCreateCardSuccess,
+          handleCreateCardError
+        );
+      } catch (errors) {
+        handleCreateCardError(errors);
+      }
+    });
+  })();
 </script>
 ```
+
+Use `examples/js-cdn/index.html` as the copy-paste starting point for this path.
 
 ## Loader API
 
@@ -148,6 +322,7 @@ Use this section for customers who import from `@vgs/collect-js`.
 - `version`: optional Collect core SDK version; production integrations should pin an explicit public version.
 - `integrity`: optional script integrity value.
 - `crossorigin`: optional script cross-origin setting.
+- `logLevel`: optional Collect log-level setting; use `none` only when the customer intentionally wants to suppress Collect logs.
 
 `loadVGSCollect(config)` resolves to the loaded Collect instance. After it resolves, call `collect.init(stateCallback)` to create a form for manual field setup.
 
@@ -174,6 +349,7 @@ Common form methods:
 - `setRouteId(routeId)`
 - `setAuthToken(token)`
 - `field(selector, properties)`
+- CMP presets: `cardNumberField`, `cardExpirationDateField`, `cardCVCField`, `cardholderNameField`
 - `reset()`
 - `submit(path, options, onSuccess?, onFailure?)`
 - `tokenize(onSuccess?, onError?)`
@@ -200,7 +376,7 @@ Common field types include `card-number`, `card-expiration-date`, `card-security
 
 Common validations include `required`, `validCardNumber`, `validCardExpirationDate`, `validCardSecurityCode`, `validSSN`, `validABARoutingNumber`, `compareValue`, `compareDate`, postal code validations, and regex validations written as `/pattern/flags`.
 
-## Submit Behavior
+## Submit Modes
 
 `form.submit(path, options, success?, failure?)` supports callbacks and promises. A successful submit resolves `{ status, data }`; validation errors reject with the form state payload passed to the failure callback.
 
@@ -212,3 +388,39 @@ Common submit options:
 - `serialization`: default JSON-like object, or `formData`.
 - `mapDotToObject`: false by default; `true`, `merge`, or `mergeArray` shape nested field names and additional data.
 - `withCredentials`: false by default.
+
+Other customer-facing submit methods:
+
+- `form.tokenize(onSuccess?, onError?)`.
+- `form.createAliases(params, onSuccess?, onError?)`.
+- `form.createCard(parameters, onSuccess?, onError?)`.
+- `form.updateCard(parameters, onSuccess?, onError?)`.
+
+Use the method that matches the customer's requested flow. Do not mix proxy submit, aliases, tokenization, and CMP card flows in one default example.
+
+## Events And State
+
+Use form and field events for UI state, not for logging sensitive input.
+
+- Form event methods: `form.on(event, callback)` and `form.off(event, callback)`.
+- Field event methods: `field.on(eventType, callback)` and `field.off(eventType, callback)`.
+- The form state callback is appropriate for rendering validation state, disabling submit, or showing customer-safe field errors.
+- Do not persist or log full form state, submit payloads, tokens, aliases, card IDs, access tokens, route IDs, or production identifiers unless the customer has provided sanitized values and explicitly needs that behavior.
+
+## Masking And Field Transforms
+
+Use masking or replacement only when the customer asks for field formatting behavior.
+
+- `field.mask(mask, maskChar?, formatChars?)`.
+- `field.mask({ mask, maskChar, formatChars, hideValue })`.
+- `field.replacePattern(regExpString, newSubStr?)`.
+
+Confirm the customer's field type and desired format before recommending a mask. For postal formats that require letters or custom formatting, verify the actual field behavior in the customer's current Collect core version before claiming support.
+
+## CMP And Session Notes
+
+For vanilla JavaScript CMP or Collect Session flows, confirm the customer has the required Collect Session form ID, backend token/auth flow, and selected operation before generating code.
+
+CMP create-card requires a Collect Session `formId` configured for CMP and `form.createCard(...)`. Include `configuration.cardAttributes` and card-attributes form events when card brand/type/product metadata should be available as the user enters the card number.
+
+Do not hardcode bearer tokens, client secrets, route IDs, production vault IDs, production CNAME details, or access tokens in browser examples. Fetch short-lived credentials from the customer's backend when a flow requires authentication, and keep examples on sandbox placeholders unless sanitized customer configuration is provided.


### PR DESCRIPTION
## Description

Adds a public `vgs-collect-js-guide` skill for AI agents integrating VGS Collect through vanilla JavaScript, `@vgs/collect-js`, or a direct Collect.js CDN script.

The skill includes loader and CDN setup guidance, compatibility notes, and customer-safe JavaScript payment examples. It also adds CI validation for the committed skill and updates README/agent guidance to reference the JavaScript-only skill.

## Motivation and Context

This mirrors the support surface from verygoodsecurity/collect-js-react-private#49 for the standalone JavaScript loader repository. The React wrapper skill remains separate; this repository skill is scoped to non-React Collect.js integrations.

## How Has This Been Tested?

- `skills-ref validate skills/vgs-collect-js-guide`
- `git diff --check`
- `git diff --cached --check`

## Screenshots (if appropriate):

N/A

## Types of Changes

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
